### PR TITLE
fix: remove the verb check when reading cache because the verb is not…

### DIFF
--- a/OaiPmh/OaiPmhRuler.php
+++ b/OaiPmh/OaiPmhRuler.php
@@ -46,7 +46,7 @@ class OaiPmhRuler
             && $resumptionToken = $queryParams['resumptionToken']
         ) {
             $cacheData = $cache->fetch($this->getcacheKey($resumptionToken));
-            if (!$cacheData || $cacheData['verb'] != $queryParams['verb']) {
+            if (!$cacheData) {
                 throw new badResumptionTokenException();
             }
             $searchParams = $cacheData;


### PR DESCRIPTION
… in cache